### PR TITLE
added "run" to docker command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Europe/Brussels
 ```
 
 Example run command (with your openHAB config)
-```docker -d -p 8080:8080 -v /tmp/configuration:/etc/openhab/ tdeckers/openhab```
+```docker run -d -p 8080:8080 -v /tmp/configuration:/etc/openhab/ tdeckers/openhab```
 
 Example run command (with Demo)
-```docker -d -p 8080:8080 tdeckers/openhab```
+```docker run -d -p 8080:8080 tdeckers/openhab```
 
 Start the Demo with: ```http://[IP-of-Docker-Host]:8080/openhab.app?sitemap=demo```
 


### PR DESCRIPTION
I assume this is a typo of some sort, since the docker command needs a command-argument.